### PR TITLE
Changes implemented to resolve issues with ios devices.

### DIFF
--- a/Space_Mapper/ios/PrivacyInfo.xcprivacy
+++ b/Space_Mapper/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+
+	<key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <!-- [1] background_fetch: UserDefaults -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>        
+    </array>
+</dict>
+</plist>

--- a/Space_Mapper/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/Space_Mapper/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:PrivacyInfo.xcprivacy">
+   </FileRef>
+   <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
    <FileRef

--- a/Space_Mapper/ios/Runner/Info.plist
+++ b/Space_Mapper/ios/Runner/Info.plist
@@ -5,19 +5,20 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.transistorsoft.fetch</string>
+		<string>com.transistorsoft.spacemapper</string>
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Space Mapper</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleDisplayName</key>
-	<string>Space Mapper</string>
 	<key>CFBundleName</key>
 	<string>Space Mapper</string>
 	<key>CFBundlePackageType</key>

--- a/Space_Mapper/lib/ui/home_view.dart
+++ b/Space_Mapper/lib/ui/home_view.dart
@@ -156,6 +156,7 @@ class HomeViewState extends State<HomeView>
 
   // Configure BackgroundFetch (not required by BackgroundGeolocation).
   void _configureBackgroundFetch() async {
+    print("test 6");
     BackgroundFetch.configure(
         BackgroundFetchConfig(
             minimumFetchInterval: 15,
@@ -168,7 +169,7 @@ class HomeViewState extends State<HomeView>
             requiresDeviceIdle: false,
             requiredNetworkType: NetworkType.NONE), (String taskId) async {
       print("[BackgroundFetch] received event $taskId");
-
+      print("test 7");
       SharedPreferences prefs = await SharedPreferences.getInstance();
       int count = 0;
       if (prefs.get("fetch-count") != null) {
@@ -177,28 +178,29 @@ class HomeViewState extends State<HomeView>
       prefs.setInt("fetch-count", ++count);
       print('[BackgroundFetch] count: $count');
 
+      //If condition below commented out by Otis, not sure how or why taskId would have this value
+      //if (taskId == 'flutter_background_fetch') {
       // Test scheduling a custom-task in fetch event.
-
-      if (taskId == 'flutter_background_fetch') {
-        BackgroundFetch.scheduleTask(TaskConfig(
-            taskId: "com.transistorsoft.customtask",
-            delay: 5000,
-            periodic: false,
-            forceAlarmManager: true,
-            stopOnTerminate: false,
-            enableHeadless: true));
-      }
+      BackgroundFetch.scheduleTask(TaskConfig(
+          taskId: "com.transistorsoft.spacemapper",
+          delay: 5000,
+          periodic: false,
+          forceAlarmManager: true,
+          stopOnTerminate: false,
+          enableHeadless: true));
+      //}
       BackgroundFetch.finish(taskId);
     });
-
+/*
     // Test scheduling a custom-task.
     BackgroundFetch.scheduleTask(TaskConfig(
-        taskId: "com.transistorsoft.customtask",
+        taskId: "com.transistorsoft.spacemapper",
         delay: 10000,
         periodic: false,
         forceAlarmManager: true,
         stopOnTerminate: false,
         enableHeadless: true));
+        */
   }
 
   void _onClickEnable(enabled) async {

--- a/Space_Mapper/pubspec.lock
+++ b/Space_Mapper/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: background_fetch
-      sha256: f70b28a0f7a3156195e9742229696f004ea3bf10f74039b7bf4c78a74fbda8a4
+      sha256: b5c298c911bc2ce41152668bc72eb0488f0665d75bc6d1e69e7d8367763eddcd
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.5"
   boolean_selector:
     dependency: transitive
     description:
@@ -1178,5 +1178,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <=3.3.0"
-  flutter: ">=3.10.0"
+  dart: ">=3.1.0 <=3.3.0"
+  flutter: ">=3.13.0"

--- a/Space_Mapper/pubspec.yaml
+++ b/Space_Mapper/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     sdk: flutter
   flutter_background_geolocation: ^4.3.0
   shared_preferences: ^2.0.8
-  background_fetch: ^1.0.1
+  background_fetch: ^1.3.5
   http: ^0.13.4
   flutter_map: ^0.14.0
   webview_flutter: ^2.8.0


### PR DESCRIPTION
- ⁠In home_view.dart, the wrong taskid was being used, a new one was created and used instead. 
- In home_view.dart, BackgroundFetch.scheduleTask was being called twice in home_view.dart. One instance was removed. 
- In pubspec.yaml, background fetch was updated from 1.0.1 to 1.3.5 . 
- In info.plist, "com.transistorsoft.spacemapper” was created and added to BGTaskSchedulerPermittedIdentifiers. 
- The documentation of transistorsofts background fetch recomended created of a privacyinfo, so I created it.